### PR TITLE
Upgrade Astro to 5.3.0 and allow minor and patch updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@astrojs/tailwind": "5.1.4",
     "@astrojs/vercel": "^8.0.1",
     "@nanostores/react": "^0.8.4",
-    "astro": "5.1.5",
+    "astro": "^5.3.0",
     "astro-auto-import": "^0.4.4",
     "astro-font": "^0.1.81",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
Resolve #7 

I opted to upgrade `astro` to the latest of conflicting versions, and allow minor and patch updates by NPM to the `astro` dependency.